### PR TITLE
Exposes xyz_format and amv_format; write_mol_to_xyz_file/_amv_file now includes lattices

### DIFF
--- a/src/tcmu/__init__.py
+++ b/src/tcmu/__init__.py
@@ -24,7 +24,7 @@ from tcmu.job.dftb import DFTBJob
 from tcmu.job.nmr import NMRJob
 from tcmu.job.orca import ORCAJob, GOATJob
 from tcmu.job.xtb import XTBJob
-from tcmu.molecule import from_string, guess_fragments, load, number_of_electrons, save, write_mol_to_amv_file, write_mol_to_xyz_file
+from tcmu.molecule import from_string, guess_fragments, load, number_of_electrons, save, xyz_format, amv_format, write_mol_to_amv_file, write_mol_to_xyz_file
 # from tcmu.report.report import SI
 from tcmu.timer import timer
 from tcmu.report import simple_sheets
@@ -47,6 +47,8 @@ __all__ = [
     "load",
     "number_of_electrons",
     "save",
+    "xyz_format",
+    "amv_format",
     "write_mol_to_amv_file",
     "write_mol_to_xyz_file",
     "get_info",

--- a/src/tcmu/molecule.py
+++ b/src/tcmu/molecule.py
@@ -301,7 +301,7 @@ def guess_fragments(mol: plams.Molecule) -> Dict[str, plams.Molecule]:
 # =============================================================================
 
 
-def xyz_format(mol: plams.Molecule, include_n_atoms: bool = True, include_lattices:bool = True) -> str:
+def xyz_format(mol: plams.Molecule, include_n_atoms: bool = True, include_lattices: bool = True) -> str:
     """Returns a string representation of a molecule in the xyz format, e.g.:
 
     C      0.00000000      0.00000000      0.00000000
@@ -316,13 +316,14 @@ def xyz_format(mol: plams.Molecule, include_n_atoms: bool = True, include_lattic
 
     if include_n_atoms:
         xyz_string = f"{len(mol.atoms)}\n"
-    
+
     xyz_string += "\n".join([f"{at.symbol:6s}{at.x:16.8f}{at.y:16.8f}{at.z:16.8f}" for at in mol.atoms])
 
     if include_lattices and len(mol.lattice):
         xyz_string += "\n" + "\n".join([f"VEC{str(i + 1):3s}{mol.lattice[i][0]:16.8f}{mol.lattice[i][1]:16.8f}{mol.lattice[i][2]:16.8f}" for i in range(0, len(mol.lattice))])
 
     return xyz_string
+
 
 def amv_format(mol: plams.Molecule, step: int, energy: Union[float, None] = None, name: Union[float, str] = None, include_lattices: bool = True) -> str:
     """Returns a string representation of a molecule in the amv format, e.g.:
@@ -339,7 +340,8 @@ def amv_format(mol: plams.Molecule, step: int, energy: Union[float, None] = None
     header += f", Name: {name}" if name is not None else ""
     header += f", Energy: {energy} Ha" if energy is not None else ""
 
-    return header + "\n" + xyz_format(mol = mol, include_n_atoms = False, include_lattices = include_lattices)
+    return header + "\n" + xyz_format(mol=mol, include_n_atoms=False, include_lattices=include_lattices)
+
 
 def write_mol_to_xyz_file(out_file: Union[str, pl.Path], mols: Union[List[plams.Molecule], plams.Molecule], include_n_atoms: bool = False) -> None:
     """Writes a list of molecules to a file in xyz format."""
@@ -353,7 +355,7 @@ def write_mol_to_xyz_file(out_file: Union[str, pl.Path], mols: Union[List[plams.
     return None
 
 
-def write_mol_to_amv_file(out_file: Union[str, pl.Path], mols: Union[List[plams.Molecule], plams.Molecule], energies: Union[List[float], None], mol_names: Union[List[str], None] = None) -> None:
+def write_mol_to_amv_file(out_file: Union[str, pl.Path], mols: Union[List[plams.Molecule], plams.Molecule], energies: Union[List[float], None] = None, mol_names: Union[List[str], None] = None) -> None:
     """Writes a list of molecules to a file in amv format."""
     out_file = pl.Path(out_file)
 

--- a/src/tcmu/molecule.py
+++ b/src/tcmu/molecule.py
@@ -7,7 +7,7 @@ from tcmu.data import atom
 from tcmu.results import result
 from tcmu.typing_utilities import ensure_list
 
-__all__ = ["load", "save", "from_string", "guess_fragments", "number_of_electrons", "write_mol_to_xyz_file", "write_mol_to_amv_file"]
+__all__ = ["load", "save", "from_string", "guess_fragments", "number_of_electrons", "xyz_format", "amv_format", "write_mol_to_xyz_file", "write_mol_to_amv_file"]
 
 
 def number_of_electrons(mol: plams.Molecule, charge: int = 0) -> int:
@@ -301,7 +301,7 @@ def guess_fragments(mol: plams.Molecule) -> Dict[str, plams.Molecule]:
 # =============================================================================
 
 
-def _xyz_format(mol: plams.Molecule, include_n_atoms: bool = True, include_lattices = True) -> str:
+def xyz_format(mol: plams.Molecule, include_n_atoms: bool = True, include_lattices:bool = True) -> str:
     """Returns a string representation of a molecule in the xyz format, e.g.:
 
     C      0.00000000      0.00000000      0.00000000
@@ -324,7 +324,7 @@ def _xyz_format(mol: plams.Molecule, include_n_atoms: bool = True, include_latti
 
     return xyz_string
 
-def _amv_format(mol: plams.Molecule, step: int, energy: Union[float, None] = None, name: Union[float, str] = None) -> str:
+def amv_format(mol: plams.Molecule, step: int, energy: Union[float, None] = None, name: Union[float, str] = None, include_lattices: bool = True) -> str:
     """Returns a string representation of a molecule in the amv format, e.g.:
 
     Geometry 1, Energy: -0.5 Ha
@@ -339,8 +339,7 @@ def _amv_format(mol: plams.Molecule, step: int, energy: Union[float, None] = Non
     header += f", Name: {name}" if name is not None else ""
     header += f", Energy: {energy} Ha" if energy is not None else ""
 
-    return header + "\n" + "\n".join([f"{at.symbol:6s}{at.x:16.8f}{at.y:16.8f}{at.z:16.8f}" for at in mol.atoms])
-
+    return header + "\n" + xyz_format(mol = mol, include_n_atoms = False, include_lattices = include_lattices)
 
 def write_mol_to_xyz_file(out_file: Union[str, pl.Path], mols: Union[List[plams.Molecule], plams.Molecule], include_n_atoms: bool = False) -> None:
     """Writes a list of molecules to a file in xyz format."""
@@ -348,7 +347,7 @@ def write_mol_to_xyz_file(out_file: Union[str, pl.Path], mols: Union[List[plams.
     out_file = pl.Path(f"{out_file}.xyz")
 
     [mol.delete_all_bonds() for mol in mols]
-    write_string = "\n\n".join([_xyz_format(mol, include_n_atoms) for mol in mols])
+    write_string = "\n\n".join([xyz_format(mol, include_n_atoms) for mol in mols])
     out_file.write_text(write_string)
 
     return None
@@ -366,7 +365,7 @@ def write_mol_to_amv_file(out_file: Union[str, pl.Path], mols: Union[List[plams.
     names = mol_names if mol_names is not None else [f"Molecule {i}" for i in range(1, len(mols) + 1)]
 
     [mol.delete_all_bonds() for mol in mols]
-    write_string = "\n\n".join([_amv_format(mol, step, energy, name) for step, (mol, energy, name) in enumerate(zip(mols, energies, names), 1)])
+    write_string = "\n\n".join([amv_format(mol, step, energy, name) for step, (mol, energy, name) in enumerate(zip(mols, energies, names), 1)])
     out_file.write_text(write_string)
 
     return None

--- a/src/tcmu/molecule.py
+++ b/src/tcmu/molecule.py
@@ -301,22 +301,28 @@ def guess_fragments(mol: plams.Molecule) -> Dict[str, plams.Molecule]:
 # =============================================================================
 
 
-def _xyz_format(mol: plams.Molecule, include_n_atoms: bool = True) -> str:
+def _xyz_format(mol: plams.Molecule, include_n_atoms: bool = True, include_lattices = True) -> str:
     """Returns a string representation of a molecule in the xyz format, e.g.:
 
     C      0.00000000      0.00000000      0.00000000
     H      1.00000000      0.00000000      0.00000000
     H      0.00000000      1.00000000      0.00000000
     H      0.00000000      0.00000000      1.00000000
-
+    VEC1   1.00000000     -1.00000000      0.00000000
     ...
     """
-    n_atoms = len(mol.atoms)
+
+    xyz_string = ""
+
     if include_n_atoms:
-        return f"{n_atoms}\n" + "\n".join([f"{at.symbol:6s}{at.x:16.8f}{at.y:16.8f}{at.z:16.8f}" for at in mol.atoms])
+        xyz_string = f"{len(mol.atoms)}\n"
+    
+    xyz_string += "\n".join([f"{at.symbol:6s}{at.x:16.8f}{at.y:16.8f}{at.z:16.8f}" for at in mol.atoms])
 
-    return "\n".join([f"{at.symbol:6s}{at.x:16.8f}{at.y:16.8f}{at.z:16.8f}" for at in mol.atoms])
+    if include_lattices and len(mol.lattice):
+        xyz_string += "\n" + "\n".join([f"VEC{str(i + 1):3s}{mol.lattice[i][0]:16.8f}{mol.lattice[i][1]:16.8f}{mol.lattice[i][2]:16.8f}" for i in range(0, len(mol.lattice))])
 
+    return xyz_string
 
 def _amv_format(mol: plams.Molecule, step: int, energy: Union[float, None] = None, name: Union[float, str] = None) -> str:
     """Returns a string representation of a molecule in the amv format, e.g.:


### PR DESCRIPTION
Requires #531 for full functionality

1. xyz_format and amv_format now supports lattices, if there are any. This translates to write_mol_to_xyz_file and write_mol_ti_amv_file also supporting them
<img width="511" height="172" alt="image" src="https://github.com/user-attachments/assets/88deeda6-8ca1-4e2f-936f-aab7cb19f505" />

2. xyz_format and amv_format are now user accessible
These are just really useful to be able to access directly. I want to be able to grab the whole .xyz string and put it into an excel sheet without having to scrape it or first having to print it to an .xyz file

3. Slight copy-paste reduction, fixes energies in write_mol_to_amv not being optional

Produced .xyz and .amv (with .txt affixed so GitHub wont complain)

[scrumpy.amv.txt](https://github.com/user-attachments/files/30659641/scrumpy.amv.txt)
[scrumpy.xyz.txt](https://github.com/user-attachments/files/30659642/scrumpy.xyz.txt)
